### PR TITLE
Update README about granting databases privileges

### DIFF
--- a/jdbc/README.md
+++ b/jdbc/README.md
@@ -1,27 +1,56 @@
-# MySQL
+# Connect with Managed Identity to Azure Database for MySQL
 
-## How to run the test?
+To connect to Azure Database for MySQL with Managed Identity using `azure_mysql_msi` extension, please follow below steps:
+
+## Creating a user-assigned Managed Identity for your VM
+Please refer to [this doc](https://docs.microsoft.com/azure/mysql/howto-connect-with-managed-identity#creating-a-user-assigned-managed-identity-for-your-vm) to create the Managed Identity.
+To do the required resource creation and role management, your account needs `Owner` permissions at the appropriate scope (your subscription or resource group). If you need assistance with role assignment, see [Assign Azure roles to manage access to your Azure subscription resources](https://docs.microsoft.com/azure/role-based-access-control/role-assignments-portal).
+
+## Configuring the Azure Database for MySQL with Azure AD authentication
+Please refer to the following links to:
+- [Set an Azure AD Admin user for your Azure Database for MySQL](https://docs.microsoft.com/azure/mysql/howto-configure-sign-in-azure-ad-authentication#setting-the-azure-ad-admin-user)
+- [Connecting to Azure Database for MySQL using Azure AD Admin user](https://docs.microsoft.com/azure/mysql/howto-configure-sign-in-azure-ad-authentication#connecting-to-azure-database-for-mysql-using-azure-ad)
+
+## Creating a database for your Managed Identity to connect to
+After connecting to your MySQL server with Azure AD Admin user, edit and run the following SQL code to create a database. Replace the value `testdb` with your database name.
+
+```sql
+CREATE DATABASE testdb;
+```
+
+## Creating a MySQL user for your Managed Identity
+Please refer to [this doc](https://docs.microsoft.com/azure/mysql/howto-connect-with-managed-identity#creating-a-mysql-user-for-your-managed-identity) to create a MySQL user for your Managed Identity.
+
+Then edit and run the following SQL code to [assign the necessary privileges](https://dev.mysql.com/doc/refman/8.0/en/grant.html#grant-database-privileges) to allow your Managed Identity to access the database.
+- Replace the value `ALL` with your needed privileges. 
+- Replace the value `testdb` with your database name. 
+- Replace the value `myuser` with your MySQL user name for your Managed Identity. 
+- Replace the value `somehost` with the public ip address of your vm.
+
+```sql
+GRANT ALL ON testdb.* TO 'myuser'@'somehost';
+```
+
+## Run the test to connect to Azure Database for MySQL with Managed Identity
 
 You can either run the test using its main method and then you pass in the JDBC URL directly, or if you are running the test using JUnit integration you will have to pass the JDBC URL using the -Durl=xxx syntax.
 
-Before connecting to Azure Database for MySQL, make sure you have [assigned the required privileges of the specific database](https://dev.mysql.com/doc/refman/8.0/en/grant.html#grant-database-privileges) to [the MySQL user for your managed identity](https://docs.microsoft.com/azure/mysql/howto-connect-with-managed-identity#creating-a-mysql-user-for-your-managed-identity).
-
-## What does the JDBC URL look like?
+### What does the JDBC URL look like?
 
 ```
 jdbc:mysql://hostname:portNumber/databaseName?sslMode=REQUIRED&defaultAuthenticationPlugin=com.azure.jdbc.msi.extension.mysql.AzureMySqlMSIAuthenticationPlugin&authenticationPlugins=com.azure.jdbc.msi.extension.mysql.AzureMySqlMSIAuthenticationPlugin&user=username
 ```
 
-### Required modifiable properties
+#### Required modifiable properties
 
 1. `hostname` is the hostname of the MySQL instance
 2. `portNumber` is the port number of the MySQL instance
 3. `databaseName` is the name of the MySQL database to connect to
-4. `username` is the username to connect with (format should be `user@tenant@hostname-only`)
+4. `username` is the username to connect with (format should be `mysql-username@hostname-only`)
 
-Note `hostname-only` is the first part of the FQDN hostname.
+Note `mysql-username` is the name of the MySQL user you created for your Managed Identity, and `hostname-only` is the first part of the FQDN hostname.
 
-### Required fixed properties
+#### Required fixed properties
 
 * `sslMode` needs to be set to REQUIRED.
 * `defaultAuthenticationPlugin` needs to be set to the implementing class name in this case `com.azure.jdbc.msi.extension.mysql.AzureMySqlMSIAuthenticationPlugin`
@@ -43,8 +72,6 @@ Note `hostname-only` is the first part of the FQDN hostname.
 You can either run the test using its main method and then you pass in the JDBC
 URL directly, or if you are running the test using JUnit integration you will
 have to pass the JDBC URL using the -Durl=xxx syntax.
-
-Before connecting to Azure Database for PostgreSQL, make sure you have [assigned the required privileges of the specific database](https://www.postgresql.org/docs/current/sql-grant.html) to [the PostgreSQL user for your managed identity](https://docs.microsoft.com/azure/postgresql/howto-connect-with-managed-identity#creating-a-postgresql-user-for-your-managed-identity).
 
 Note only user-assigned managed identity can be supported at this time because
 the JDBC driver does not have a username callback.

--- a/jdbc/README.md
+++ b/jdbc/README.md
@@ -4,6 +4,8 @@
 
 You can either run the test using its main method and then you pass in the JDBC URL directly, or if you are running the test using JUnit integration you will have to pass the JDBC URL using the -Durl=xxx syntax.
 
+Before connecting to Azure Database for MySQL, make sure you have [assigned the required privileges of the specific database](https://dev.mysql.com/doc/refman/8.0/en/grant.html#grant-database-privileges) to [the MySQL user for your managed identity](https://docs.microsoft.com/azure/mysql/howto-connect-with-managed-identity#creating-a-mysql-user-for-your-managed-identity).
+
 ## What does the JDBC URL look like?
 
 ```
@@ -27,7 +29,7 @@ Note `hostname-only` is the first part of the FQDN hostname.
 
 ## Background information
 
-* https://docs.microsoft.com/en-us/azure/mysql/howto-connect-with-managed-identity 
+* https://docs.microsoft.com/azure/mysql/howto-connect-with-managed-identity 
 * https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-connp-props-authentication.html
 * https://techcommunity.microsoft.com/t5/azure-database-for-mysql-blog/how-to-connect-to-azure-database-for-mysql-using-managed/ba-p/1518196#:~:text=%20How%20to%20connect%20to%20Azure%20Database%20for,the%20Managed%20Identity%20GUID%20and%20then...%20More%20
 
@@ -41,6 +43,8 @@ Note `hostname-only` is the first part of the FQDN hostname.
 You can either run the test using its main method and then you pass in the JDBC
 URL directly, or if you are running the test using JUnit integration you will
 have to pass the JDBC URL using the -Durl=xxx syntax.
+
+Before connecting to Azure Database for PostgreSQL, make sure you have [assigned the required privileges of the specific database](https://www.postgresql.org/docs/current/sql-grant.html) to [the PostgreSQL user for your managed identity](https://docs.microsoft.com/azure/postgresql/howto-connect-with-managed-identity#creating-a-postgresql-user-for-your-managed-identity).
 
 Note only user-assigned managed identity can be supported at this time because
 the JDBC driver does not have a username callback.
@@ -67,6 +71,6 @@ Note `hostname-only` is the first part of the FQDN hostname.
 
 ## Background information
 
-* https://docs.microsoft.com/en-us/azure/postgresql/howto-connect-with-managed-identity
+* https://docs.microsoft.com/azure/postgresql/howto-connect-with-managed-identity
 * https://github.com/spaceteams/postgres-rds-authentication-plugin
 * https://github.com/pgjdbc/pgjdbc/blob/master/pgjdbc/src/main/java/org/postgresql/plugin/AuthenticationPlugin.java


### PR DESCRIPTION
This pr updated the README to add description about granting databases privileges to the managed identity, which is not mentioned in the ms docs of https://docs.microsoft.com/azure/mysql/howto-connect-with-managed-identity and https://docs.microsoft.com/azure/postgresql/howto-connect-with-managed-identity. When ignoring such step, the connection request to a specific database will be denied due to lack of access permission. 