### PR TITLE
Fix data.azurerm_client_config.current.object_id return "" empty when upgrading az cli to 2.37.0

### DIFF
--- a/demo/deployment/terraform/main.tf
+++ b/demo/deployment/terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.0.1"
+      version = "3.9.0"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"


### PR DESCRIPTION
**Context**

When running [demo](https://github.com/Azure/azure-jdbc-msi-extension/tree/samples/howto-demo/demo) by following the guide in the [README.md](https://github.com/Azure/azure-jdbc-msi-extension/blob/samples/howto-demo/demo/README.md), the same issue happens as the https://github.com/hashicorp/terraform-provider-azurerm/issues/16982 described.

**Solution**
Upgrade version of `hashicorp/azurerm` to 3.9.0.
